### PR TITLE
fix: add missing schema_name arg to list_materialized_views

### DIFF
--- a/src/schema_tools.py
+++ b/src/schema_tools.py
@@ -138,7 +138,7 @@ def register_schema_tools(mcp: FastMCP):
             return f"Error listing schemas: {str(e)}"
 
     @mcp.tool
-    def list_materialized_views() -> str:
+    def list_materialized_views(schema_name: str = "public") -> str:
         """
         List all materialized views in a specific schema.
 
@@ -149,7 +149,7 @@ def register_schema_tools(mcp: FastMCP):
             List of materialized views
         """
         rw = setup_risingwave_connection()
-        query = "SHOW MATERIALIZED VIEWS"
+        query = f"SHOW MATERIALIZED VIEWS FROM {schema_name}"
         try:
             result = rw.fetch(query, format=OutputFormat.DATAFRAME)
             return result.to_json()


### PR DESCRIPTION
## Summary
- Adds the `schema_name` parameter to `list_materialized_views()` function
- The docstring documented this parameter but it was missing from the function signature
- Uses `SHOW MATERIALIZED VIEWS FROM {schema_name}` to filter by schema

Fixes #3

## Test plan
- [ ] Verify `list_materialized_views()` returns MVs from public schema by default
- [ ] Verify `list_materialized_views(schema_name="other_schema")` filters correctly

🤖 Generated with [Claude Code](https://claude.ai/code)