### PR TITLE
feat: add Docker containerization and CI/CD workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+venv
+.venv
+.vscode/
+.env
+__pycache__
+*.pyc
+.git
+.gitignore
+tests/
+*.md
+LICENSE

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  IMAGE: risingwavelabs/risingwave-mcp-server
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ ./src/
+
+ENV MCP_TRANSPORT=streamable-http
+ENV MCP_HOST=0.0.0.0
+ENV MCP_PORT=8000
+
+EXPOSE 8000
+
+CMD ["python", "src/main.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 fastmcp
 risingwave-py
 psycopg2-binary
-asyncio
-psycopg2

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastmcp import FastMCP
 from explain import explain_analyze, explain_query, explain_distsql
 
@@ -96,4 +98,10 @@ def register_tools():
 
 if __name__ == "__main__":
     register_tools()
-    mcp.run(transport="stdio")
+    transport = os.getenv("MCP_TRANSPORT", "stdio")
+    host = os.getenv("MCP_HOST", "127.0.0.1")
+    port = int(os.getenv("MCP_PORT", "8000"))
+    if transport == "stdio":
+        mcp.run(transport="stdio")
+    else:
+        mcp.run(transport=transport, host=host, port=port)


### PR DESCRIPTION
## Summary
- Add `Dockerfile` (Python 3.12 slim, multi-platform amd64/arm64)
- Add `.dockerignore` to keep build context lean
- Add GitHub Actions workflow to build and push images to Docker Hub on push to `main`, release tags (`v*`), or `workflow_dispatch`
- Update `main.py` to support configurable transport via `MCP_TRANSPORT` env var (`stdio` default for local, `streamable-http`/`sse` for container)

## Prerequisites
- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the repo settings

## Test plan
- [ ] Verify `docker build` succeeds locally
- [ ] Verify container starts with `docker run -p 8000:8000 -e RISINGWAVE_CONNECTION_STR=... risingwave-mcp`
- [ ] Verify GitHub Actions workflow triggers on push to main
- [ ] Verify image is pushed to Docker Hub as `risingwavelabs/risingwave-mcp-server`