### PR TITLE
fix: add QEMU for arm64 build, improve tag strategy, update README

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -35,7 +38,7 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@
 
 ## Installation
 
+### Option 1: Docker (Recommended)
+
+```bash
+docker pull risingwavelabs/risingwave-mcp-server:0.1.0
+```
+
+### Option 2: From Source
+
 ```bash
 git clone https://github.com/risingwavelabs/risingwave-mcp.git
 cd risingwave-mcp
@@ -136,6 +144,34 @@ You can also spin up a free-tier cluster in seconds:
 2. Restart Claude Desktop to apply changes.
 
 ---
+
+### Docker
+
+Run the MCP server as a container with HTTP transport:
+
+```bash
+docker run -p 8000:8000 \
+  -e RISINGWAVE_CONNECTION_STR="postgresql://root:root@host.docker.internal:4566/dev" \
+  risingwavelabs/risingwave-mcp-server:0.1.0
+```
+
+The server listens on `http://localhost:8000/mcp` by default. You can configure it with environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_TRANSPORT` | `streamable-http` | Transport protocol (`streamable-http`, `sse`, `stdio`) |
+| `MCP_HOST` | `0.0.0.0` | Listen address |
+| `MCP_PORT` | `8000` | Listen port |
+
+#### Verify It Works
+
+```bash
+# Check the server is running
+curl -s http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
 
 ### Manual Testing (Dev / CI)
 


### PR DESCRIPTION
## Summary
- Add `docker/setup-qemu-action` for arm64 cross-compilation on amd64 runners
- Replace `type=ref,event=branch` with `type=raw,value=latest,enable={{is_default_branch}}` — push to main tags `latest` instead of `main`
- Add Docker installation and usage sections to README (pull, run, env vars, verify curl)

## Tag matrix after this change

| Trigger | Tags |
|---------|------|
| push `main` | `latest`, `<sha>` |
| tag `v0.1.0` | `0.1.0`, `0.1`, `<sha>` |

## Test plan
- [x] Verify arm64 build succeeds in CI with QEMU
- [x] Verify `latest` tag is pushed on main branch
- [x] Verify README docker run example works