### PR TITLE
fix: restore Python 3.8-3.11 compatibility in iceberg SQL builders

### DIFF
--- a/src/iceberg_tools.py
+++ b/src/iceberg_tools.py
@@ -297,9 +297,10 @@ def register_iceberg_tools(mcp: FastMCP):
         if s3_secret_key:
             params.append(f"s3.secret.key = '{escape_sql_string(s3_secret_key)}'")
 
+        params_sql = ",\n    ".join(params)
         query = f"""CREATE SINK {sink_name} FROM {source_object}
 WITH (
-    {',\n    '.join(params)}
+    {params_sql}
 )"""
 
         try:
@@ -357,9 +358,10 @@ WITH (
         if s3_secret_key:
             params.append(f"s3.secret.key = '{escape_sql_string(s3_secret_key)}'")
 
+        params_sql = ",\n    ".join(params)
         query = f"""CREATE SOURCE {source_name}
 WITH (
-    {',\n    '.join(params)}
+    {params_sql}
 )"""
 
         try:


### PR DESCRIPTION
## Summary
- avoid backslashes inside f-string expressions in Iceberg SQL builders
- fix both the CREATE SINK and CREATE SOURCE code paths in `src/iceberg_tools.py`
- restore import-time compatibility for Python 3.8-3.11

## Validation
- `python3.8 -m py_compile src/*.py`
- `python3.11 -m py_compile src/*.py`
- `python3.12 -m py_compile src/*.py`
- `python3.13 -m py_compile src/*.py`
- `python3.11 -m venv /tmp/rwmcp-ci && source /tmp/rwmcp-ci/bin/activate && pip install -r requirements.txt && python -m compileall -q src && python -c "import sys; sys.path.insert(0, 'src'); import main"`
