### PR TITLE
build: align Python support policy to 3.10+

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -1,0 +1,34 @@
+name: Python Compatibility
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  compile-and-import:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.11', '3.12', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Compile Python sources
+        run: python -m compileall -q src
+
+      - name: Import main module
+        run: python -c "import sys; sys.path.insert(0, 'src'); import main"

--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ docker pull risingwavelabs/risingwave-mcp-server:0.1.0
 
 ### Option 2: From Source
 
+Requires Python 3.10 or newer.
+
 ```bash
 git clone https://github.com/risingwavelabs/risingwave-mcp.git
 cd risingwave-mcp

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ docker pull risingwavelabs/risingwave-mcp-server:0.1.0
 
 ### Option 2: From Source
 
-Requires Python 3.10 or newer.
-
 ```bash
 git clone https://github.com/risingwavelabs/risingwave-mcp.git
 cd risingwave-mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <your.email@example.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 fastmcp = "^0.1.0"
 risingwave-py = "^0.1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <your.email@example.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 fastmcp = "^0.1.0"
 risingwave-py = "^0.1.0"
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to compile and import the server on supported Python versions
- update `pyproject.toml` to declare Python 3.10+
- update the README source-install instructions to say Python 3.10+ explicitly
- align the compatibility workflow matrix to 3.10/3.11/3.12/3.13

## Why
`fastmcp` declares `Requires-Python >=3.10`, so keeping `^3.8` in project metadata is inaccurate even after the syntax bug is fixed.

## Validation
- based on the earlier CI evidence from #17: 3.11/3.12/3.13 pass, 3.8 fails during dependency installation because `fastmcp` does not support it
- local syntax/import validation already passed on 3.11 in the fixed branch

## Merge plan
- merge #16 first
- merge this PR next
- #17 can be treated as superseded evidence for the policy decision
