### PR TITLE
ci: enforce Python support invariants

### DIFF
--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -32,3 +32,25 @@ jobs:
 
       - name: Import main module
         run: python -c "import sys; sys.path.insert(0, 'src'); import main"
+
+  lint-and-unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest ruff
+
+      - name: Ruff lint
+        run: ruff check src
+
+      - name: Unit tests
+        run: pytest tests/test_tools.py -q

--- a/src/cluster_tools.py
+++ b/src/cluster_tools.py
@@ -123,7 +123,7 @@ def register_cluster_tools(mcp: FastMCP):
         try:
             result = rw.fetch(query, format=OutputFormat.DATAFRAME)
             return result.to_json()
-        except Exception as e:
+        except Exception:
             # Fall back to SHOW CLUSTER if the catalog query fails
             try:
                 result = rw.fetch("SHOW CLUSTER", format=OutputFormat.DATAFRAME)


### PR DESCRIPTION
## Summary
- add a CI lint-and-unit-test job on Python 3.11
- run `ruff check src` in CI so the documented Python-floor invariants are actually enforced
- run `pytest tests/test_tools.py -q` in CI as a lightweight functional guardrail
- fix the current unused-exception binding in `src/cluster_tools.py` so `ruff` passes cleanly

## Why
PR #20 documents the Python support invariants. This PR makes the key ones executable in CI instead of leaving them as documentation only.

## Validation
- `ruff check src`
- `pytest tests/test_tools.py -q`
