### PR TITLE
ci: add ruff + pytest enforcement on top of compat matrix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- 1-3 sentences describing what this PR changes and why. -->
+
+## Python compatibility checklist
+
+See `AGENTS.md` for the invariants this checklist enforces.
+
+- [ ] Verified that any new syntax compiles on the minimum supported Python (`python3.10 -m compileall -q src`).
+- [ ] If `requirements.txt` was changed, verified each new/updated dep's PyPI `Requires-Python` still permits the declared floor in `pyproject.toml`.
+- [ ] If the declared Python floor changed, `pyproject.toml`, README, and the CI matrix were updated together in this PR.
+- [ ] `python -c "import sys; sys.path.insert(0, 'src'); import main"` still succeeds (import-time startup is a hard invariant).
+
+## Test plan
+
+<!-- How did you verify this works? Be concrete. -->

--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -32,3 +32,25 @@ jobs:
 
       - name: Import main module
         run: python -c "import sys; sys.path.insert(0, 'src'); import main"
+
+  lint-and-unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest ruff
+
+      - name: Ruff lint
+        run: ruff check src
+
+      - name: Unit tests
+        run: pytest tests/test_tools.py -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Repo-level constraints that agents (and humans) must honor when editing
+this codebase. Keep this file short and actionable.
+
+## 1. Python floor is **3.10+**, bounded by dependencies
+
+The supported Python range is set by what the dependencies in
+`requirements.txt` can install, **not** by stylistic preference.
+Currently, `fastmcp` has `Requires-Python >=3.10`, so the floor is
+**Python 3.10**.
+
+**Before lowering** `requires-python` / `python = "^X.Y"` in
+`pyproject.toml`, verify every dependency's PyPI metadata supports the
+new floor:
+
+```bash
+for pkg in $(awk -F'[<>=!~ ]' '{print $1}' requirements.txt); do
+  python -c "import urllib.request, json; \
+    d = json.loads(urllib.request.urlopen(f'https://pypi.org/pypi/$pkg/json').read()); \
+    print(f'$pkg', d['info'].get('requires_python', 'unknown'))"
+done
+```
+
+When a dependency raises its floor, update `pyproject.toml`, README,
+and the CI matrix **in the same PR**. Don't let declared support drift
+above the real install floor.
+
+## 2. Syntax must compile on the lowest supported version
+
+Local Python is not the source of truth — the CI matrix is. Common
+gotchas that compile on newer Python but fail on the floor:
+
+- f-string expression part containing `\` (allowed only from 3.12+, PEP 701)
+- PEP 604 union syntax `X | Y` in type hints (allowed from 3.10+)
+- `typing.Self` (allowed from 3.11+)
+- `tomllib` (stdlib only from 3.11+)
+
+**Verify before opening a PR**:
+
+```bash
+python3.10 -m compileall -q src   # use pyenv/docker if local lacks 3.10
+```
+
+`ruff` is configured with `target-version = "py310"` so the linter
+will also catch these statically. Run `ruff check src/` before pushing.
+
+## 3. `import main` is a hard invariant
+
+A startup-time import failure means the MCP server cannot start, so
+**every tool is broken at once**. CI enforces that
+
+```bash
+python -c "import sys; sys.path.insert(0, 'src'); import main"
+```
+
+succeeds on every supported Python version. Any change that breaks
+this smoke test is a release blocker. If you add new top-level imports
+in `src/main.py` or any module it transitively loads, run the smoke
+test locally first.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,9 @@ risingwave-py = "^0.1.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+target-version = "py310"
+# When opening a PR, run `ruff check src/` locally. CI also enforces this on
+# every supported Python version, but catching version-specific syntax issues
+# early in the editor / pre-push is much cheaper than waiting on CI.

--- a/src/cluster_tools.py
+++ b/src/cluster_tools.py
@@ -123,7 +123,7 @@ def register_cluster_tools(mcp: FastMCP):
         try:
             result = rw.fetch(query, format=OutputFormat.DATAFRAME)
             return result.to_json()
-        except Exception as e:
+        except Exception:
             # Fall back to SHOW CLUSTER if the catalog query fails
             try:
                 result = rw.fetch("SHOW CLUSTER", format=OutputFormat.DATAFRAME)


### PR DESCRIPTION
## Summary

PR B of the follow-up from #16 / #19 (Python compat invariants). Stacked on top of #20 which is now merged into `main`; supersedes the originally-opened #21 (closed because its base branch `opus/agents-md-and-ruff-target` was deleted on merge of #20).

## Changes

- Add `lint-and-unit-tests` job to `.github/workflows/python-compat.yml`:
  - Runs on Python 3.11
  - `ruff check src` — uses `[tool.ruff] target-version = "py310"` from #20
  - `pytest tests/test_tools.py -q` — wires existing test file into CI
- Drive-by: `src/cluster_tools.py:126` removes unused `as e` exception binding (F841, caught by the new ruff config)

## Verification

Local:
- `ruff check src` → pass
- `pytest tests/test_tools.py -q` → pass

## Refs

- Originally opened as #21, auto-closed when base branch was deleted after #20 squash-merge
- Builds on #20 (AGENTS.md + ruff target + PR template)